### PR TITLE
Add support for nn::err::ApplicationErrorArg

### DIFF
--- a/include/nn/err.h
+++ b/include/nn/err.h
@@ -1,0 +1,31 @@
+#pragma once 
+
+#include "settings.h"
+
+namespace nn {
+    namespace err {
+        enum ErrorCodeCategoryType : u32
+        {
+            unk1,
+            unk2,
+        };
+
+        class ApplicationErrorArg {
+            public:
+                ApplicationErrorArg();
+                ApplicationErrorArg(u32 error_code, const char* dialog_message, const char* fullscreen_message, const nn::settings::LanguageCode& languageCode);
+                void SetApplicationErrorCodeNumber(u32 error_code);
+                void SetDialogMessage(const char* message);
+                void SetFullScreenMessage(const char* message);
+            
+                u64 unk;
+                u32 error_code;
+                nn::settings::LanguageCode language_code;
+                char dialog_message[2048];
+                char fullscreen_message[2048];
+        };
+
+        u32 MakeErrorCode(ErrorCodeCategoryType err_category_type, u32 errorCodeNumber);
+        void ShowApplicationError(const ApplicationErrorArg& arg);
+    }
+}


### PR DESCRIPTION
Usage examples:
```cpp
#include "nn/err.h"
...
// First constructor
nn::err::ApplicationErrorArg error = nn::err::ApplicationErrorArg();
error.SetApplicationErrorCodeNumber(69);
error.SetDialogMessage("Dialog message");
error.SetFullScreenMessage("Fullscreen message");
nn::err::ShowApplicationError(error);```

---------------------------------------------------------------------------------------
// Second constructor
nn::err::ApplicationErrorArg error = nn::err::ApplicationErrorArg(69, "Dialog message", "Fullscreen message", nn::settings::LanguageCode::Make(nn::settings::Language::Language_English));
nn::err::ShowApplicationError(error);```