### PR TITLE
Fix upload_release.yml

### DIFF
--- a/.github/workflows/upload_release.yml
+++ b/.github/workflows/upload_release.yml
@@ -9,11 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     container: devkitpro/devkita64:latest
     steps:
-    - uses: actions/checkout@master
+    - name: Clone repo
+      run: git clone --recurse-submodules $GITHUB_SERVER_URL/$GITHUB_REPOSITORY .
     - name: make
       run: make
     - name: Prepare ZIP
-      run: mkdir exefs && cp Skyline600.nso exefs/subsdk1 && cp cross.npdm exefs/main.npdm && zip Skyline.zip exefs -r
+      run: mkdir exefs && cp Skyline600.nso exefs/subsdk9 && cp cross.npdm exefs/main.npdm && bsdtar -a -cf Skyline.zip exefs
     - name: Upload build artifact
       uses: actions/upload-artifact@v1
       with:


### PR DESCRIPTION
Clone manually because the docker container uses debian 9, which only 
has up to git 2.11.0 in its package manager. actions/checkout requires 
git >=2.18 to download with submodules.
Use "bsdtar" to zip instead of "zip" so we don't need to download "zip".
Also, name the subsdk subsdk9 instead of 1, because 9 is used elsewhere in the repo.