### PR TITLE
Allocate Inline Hook Handlers, Map Them in front of main, and Reduce Handler Size

### DIFF
--- a/include/skyline/efl/service.hpp
+++ b/include/skyline/efl/service.hpp
@@ -7,9 +7,8 @@ namespace skyline::efl {
 
 class EflSlService {
    private:
-    static constexpr auto SKYLINE_MODULE_NUMBER = 0x1A4;
-    static constexpr Result SERVICE_INIT_FAILED = MAKERESULT(SKYLINE_MODULE_NUMBER, 0);
-    static constexpr Result INVALID_PLUGIN_NAME = MAKERESULT(SKYLINE_MODULE_NUMBER, 1);
+    static constexpr Result SERVICE_INIT_FAILED = MAKERESULT(Module_Skyline, SkylineError_SlServiceInitFailed);
+    static constexpr Result INVALID_PLUGIN_NAME = MAKERESULT(Module_Skyline, SkylineError_InvalidPluginName);
 
     EflSlService();
     EflSlService(const EflSlService&) = delete;

--- a/include/skyline/nx/kernel/jit.h
+++ b/include/skyline/nx/kernel/jit.h
@@ -31,7 +31,7 @@ typedef struct {
  * @param size Size of the JIT buffer.
  * @return Result code.
  */
-Result jitCreate(Jit* j, size_t size);
+Result jitCreate(Jit* j, void* src_addr, size_t size);
 
 /**
  * @brief Transition a JIT buffer to have writable permission.

--- a/include/skyline/nx/result.h
+++ b/include/skyline/nx/result.h
@@ -40,6 +40,7 @@ enum {
     Module_HomebrewLoader = 347,
     Module_LibnxNvidia = 348,
     Module_LibnxBinder = 349,
+    Module_Skyline = 0x1A4,
 };
 
 /// Kernel error codes
@@ -176,4 +177,12 @@ enum {
     LibnxNvidiaError_SharedMemoryTooSmall,  ///< Maps to Nvidia: 0x1000
     LibnxNvidiaError_FileOperationFailed,   ///< Maps to Nvidia: 0x30003
     LibnxNvidiaError_IoctlFailed,           ///< Maps to Nvidia: 0x3000F
+};
+
+/// skyline error codes
+enum {
+    SkylineError_SlServiceInitFailed = 1,
+    SkylineError_InvalidPluginName,
+    SkylineError_InlineHookHandlerSizeInvalid,
+    SkylineError_InlineHookPoolExhausted,
 };

--- a/include/types.h
+++ b/include/types.h
@@ -78,6 +78,8 @@ typedef void (*ThreadFunc)(void*);
 
 #define INVALID_HANDLE ((Handle)0)
 
+#define PAGE_SIZE 0x1000
+
 #ifndef ALIGN_UP
 #define ALIGN_UP(x, a) (((x) + ((a)-1)) & ~((a)-1))
 #endif

--- a/source/skyline/nx/kernel/jit.c
+++ b/source/skyline/nx/kernel/jit.c
@@ -10,7 +10,7 @@
 #include "skyline/nx/runtime/env.h"
 #include "types.h"
 
-Result jitCreate(Jit* j, size_t size) {
+Result jitCreate(Jit* j, void* rx_addr, size_t size) {
     JitType type;
 
     // Use new jit primitive introduced in [4.0.0+], if available.
@@ -38,7 +38,7 @@ Result jitCreate(Jit* j, size_t size) {
     j->type = type;
     j->size = size;
     j->src_addr = src_addr;
-    j->rx_addr = virtmemReserve(j->size);
+    j->rx_addr = rx_addr != NULL ? rx_addr : virtmemReserve(j->size);
     j->handle = INVALID_HANDLE;
     j->is_executable = 0;
 

--- a/source/skyline/utils/armutils.s
+++ b/source/skyline/utils/armutils.s
@@ -51,22 +51,32 @@
     add sp, sp, #0x100
 .endm
 
+
+CODE_BEGIN inlineHandlerImpl
+    armBackupRegisters
+
+    // branch and link to hook callback
+    mov x0, sp
+    ldr x16, [x17, #8]
+    blr x16
+
+    armRecoverRegisters
+
+    // branch to trampoline
+    ldr x16, [x17, #0x10]
+    br x16
+
+CODE_END
+
+
 .global inlineHandlerStart
 .global inlineHandlerEnd
 
 CODE_BEGIN inlineHandler
 inlineHandlerStart:
-    armBackupRegisters
-
-    mov x0, sp
-    ldr x17, inlineHandlerEnd
-    blr x17
-
-    armRecoverRegisters
-
-    // jump to trampoline
-    ldr x17, inlineHandlerEnd+8
-    br x17
+    adr x17, inlineHandlerEnd
+    ldr x16, [x17]
+    br x16
 
 CODE_END
 inlineHandlerEnd:


### PR DESCRIPTION
should improve compatibility with hooks now being one instruction in length