### PR TITLE
Mount romfs ourselves

### DIFF
--- a/include/skyline/utils/cpputils.hpp
+++ b/include/skyline/utils/cpputils.hpp
@@ -16,8 +16,6 @@ enum region : u8 { Text, Rodata, Data, Bss, Heap };
 
 extern std::string g_RomMountStr;
 
-extern nn::os::EventType g_RomMountedEvent;
-
 extern u64 g_MainTextAddr;
 extern u64 g_MainRodataAddr;
 extern u64 g_MainDataAddr;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -7,6 +7,8 @@
 char ALIGNA(0x1000) exception_handler_stack[0x4000];
 nn::os::UserExceptionInfo exception_info;
 
+const char* RomMountName = "rom";
+
 void exception_handler(nn::os::UserExceptionInfo* info) {
     skyline::logger::s_Instance->LogFormat("Exception occurred!\n");
 
@@ -20,11 +22,6 @@ void exception_handler(nn::os::UserExceptionInfo* info) {
 }
 
 static skyline::utils::Task* after_romfs_task = new skyline::utils::Task{[]() {
-    // wait for ROM to be mounted
-    if (!nn::os::TimedWaitEvent(&skyline::utils::g_RomMountedEvent, nn::TimeSpan::FromSeconds(10))) {
-        skyline::logger::s_Instance->SendRawFormat("[ROM Waiter] Missed ROM mount event!");
-    }
-
     // mount sd
     Result rc = nn::fs::MountSdCardForDebug("sd");
     skyline::logger::s_Instance->LogFormat("[skyline_main] Mounted SD (0x%x)", rc);
@@ -38,10 +35,13 @@ void stub() {}
 Result (*nnFsMountRomImpl)(char const*, void*, unsigned long);
 
 Result handleNnFsMountRom(char const* path, void* buffer, unsigned long size) {
-    Result rc = nnFsMountRomImpl(path, buffer, size);
-    skyline::logger::s_Instance->LogFormat("[handleNnFsMountRom] Mounted ROM (0x%x)", rc);
-    skyline::utils::g_RomMountStr = std::string(path) + ":/";
-    nn::os::SignalEvent(&skyline::utils::g_RomMountedEvent);
+    Result rc = 0;
+    if(strcmp(path, RomMountName) == 0) {
+        skyline::logger::s_Instance->LogFormat("[handleNnFsMountRom] Prevented game from double mounting as '%s'", RomMountName);
+    }
+    else {
+        rc = nnFsMountRomImpl(path, buffer, size);
+    }
     nn::os::WaitEvent(&after_romfs_task->completionEvent);
     return rc;
 }
@@ -64,14 +64,29 @@ void skyline_main() {
     nn::os::SetUserExceptionHandler(exception_handler, exception_handler_stack, sizeof(exception_handler_stack),
                                     &exception_info);
 
-    // hook to get a signal upon rom mount
-    nn::os::InitializeEvent(&skyline::utils::g_RomMountedEvent, false, nn::os::EventClearMode_AutoClear);
+    // hook to prevent the game from double mounting romfs
     A64HookFunction(reinterpret_cast<void*>(nn::fs::MountRom), reinterpret_cast<void*>(handleNnFsMountRom),
                     (void**)&nnFsMountRomImpl);
 
     // manually init nn::ro ourselves, then stub it so the game doesn't try again
     nn::ro::Initialize();
     A64HookFunction(reinterpret_cast<void*>(nn::ro::Initialize), reinterpret_cast<void*>(stub), NULL);
+
+    // mount rom
+    u64 cache_size = 0;
+    Result rc;
+    rc = nn::fs::QueryMountRomCacheSize(&cache_size);
+    if(R_SUCCEEDED(rc)) {
+        u8* cache = new u8[cache_size];
+        rc = nnFsMountRomImpl(RomMountName, cache, cache_size);
+        skyline::logger::s_Instance->LogFormat("[skyline_main] Mounted Rom (0x%x)", rc);
+        if (R_FAILED(rc)) {
+            delete[] cache;
+        }
+    }
+    else {
+        skyline::logger::s_Instance->LogFormat("[skyline_main] QueryMountRomCacheSize failed (0x%x)", rc);
+    }
 
     skyline::logger::s_Instance->LogFormat("[skyline_main] text: 0x%" PRIx64 " | rodata: 0x%" PRIx64
                                            " | data: 0x%" PRIx64 " | bss: 0x%" PRIx64 " | heap: 0x%" PRIx64,

--- a/source/skyline/utils/cpputils.cpp
+++ b/source/skyline/utils/cpputils.cpp
@@ -7,8 +7,6 @@ namespace skyline {
 
 std::string utils::g_RomMountStr = "rom:/";
 
-nn::os::EventType utils::g_RomMountedEvent;
-
 u64 utils::g_MainTextAddr;
 u64 utils::g_MainRodataAddr;
 u64 utils::g_MainDataAddr;


### PR DESCRIPTION
- Runs plugins earlier.
- Avoids a potential crash if the rom is not yet mounted after >10 seconds.
- Avoids a potential crash if the game doesn't mount rom as "rom" and mounts too early for skyline to hook it.

Tested with smash ultimate.
Potential memory leak if the game mounts as "rom" as well? Wasn't sure if it'd be safe to free the game's buffer.