### PR TITLE
Return a successful result on socket stub

### DIFF
--- a/source/skyline/logger/TcpLogger.cpp
+++ b/source/skyline/logger/TcpLogger.cpp
@@ -12,7 +12,9 @@ namespace skyline::logger {
 int g_tcpSocket;
 bool g_loggerInit = false;
 
-void stub(){};
+Result stub(){
+    return 0;
+};
 
 void TcpLogger::Initialize() {
     const size_t poolSize = 0x100000;


### PR DESCRIPTION
Fixes being unable to enter the local wireless menu in smash ultimate.
Logging dies and stays dead after using local wireless.
Solves  #26