### PR TITLE
Change size of nn::mem::StandardAllocator

### DIFF
--- a/include/nn/mem.h
+++ b/include/nn/mem.h
@@ -26,6 +26,7 @@ namespace mem {
         bool mIsEnabledThreadCache;  // _1
         u16 _2;
         u64* mAllocAddr;  // _4
+        u8 _12[20];
     };
 };  // namespace mem
 };  // namespace nn


### PR DESCRIPTION
16 bytes is too small and an extra 20 bytes puts it at 36 bytes long, which appears to be enough, at least it fixed all of my issues. The actual compile size is 40 bytes but that shouldn't make a massive difference here.