### PR TITLE
changing build yml to use master for upload action

### DIFF
--- a/.github/workflows/upload_release.yml
+++ b/.github/workflows/upload_release.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         name: zip
     - name: Upload Release
-      uses: majkrzak/create-release@eb634df3a52e2314e43a6265e48de2971aa4947c
+      uses: majkrzak/create-release@master
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         name: beta

--- a/.github/workflows/upload_release.yml
+++ b/.github/workflows/upload_release.yml
@@ -3,7 +3,7 @@ name: Upload Release
 on:
   push:
     branches: [ master ]
-
+ 
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
on my fork, changing to master made the action perform the upload correctly, despite the deprecation warnings in the upload action. It may be wise at some point to rewrite the workflow to use a different/newer/more maintained release action out there, but for now this *should* fix it.